### PR TITLE
Job removal fails sometimes

### DIFF
--- a/foreman_debian.gemspec
+++ b/foreman_debian.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'foreman_debian'
-  s.version = '0.1.0'
+  s.version = '0.1.1'
   s.summary = 'Foreman wrapper for debian'
   s.description = 'Wrapper around foreman and Procfile concept. It implements basic exporting, installing and uninstalling of initd scripts and monit configs for debian.'
   s.authors = %w(cargomedia tomaszdurka)
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*', 'templates/*']
   s.executables = ['foreman-debian']
 
-  s.add_runtime_dependency 'clamp', '~> 0.5'
+  s.add_runtime_dependency 'clamp', '~> 0.6'
   s.add_runtime_dependency 'foreman', '~> 0.63'
 
   s.add_development_dependency 'rake', '~> 10.3'

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -32,27 +32,25 @@ module ForemanDebian
       def start
         threads = []
         each_file do |path|
-          threads << Thread.new { start_file(path) }
+          threads << Thread.new do
+            exec_command("#{path.to_s} start")
+            @output.info "  start  #{path.to_s}"
+            exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
+          end
         end
         ThreadsWait.all_waits(*threads)
       end
 
       def stop
+        threads = []
         each_file do |path|
-          stop_file(path)
+          @output.info "   stop  #{path.to_s}"
+          threads << Thread.new do
+            exec_command("#{path.to_s} stop")
+          end
+          exec_command("update-rc.d -f #{path.basename} remove") if path.dirname.eql? @system_export_path
         end
-      end
-
-      def start_file(path)
-        exec_command("#{path.to_s} start")
-        @output.info "  start  #{path.to_s}"
-        exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
-      end
-
-      def stop_file(path)
-        exec_command("#{path.to_s} stop")
-        @output.info "   stop  #{path.to_s}"
-        exec_command("update-rc.d -f #{path.basename} remove") if path.dirname.eql? @system_export_path
+        ThreadsWait.all_waits(*threads)
       end
 
       def remove_file(path)

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -35,8 +35,8 @@ module ForemanDebian
           threads << Thread.new do
             exec_command("#{path.to_s} start")
             @output.info "  start  #{path.to_s}"
-            exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
           end
+          exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
         end
         ThreadsWait.all_waits(*threads)
       end

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -38,11 +38,9 @@ module ForemanDebian
       end
 
       def stop
-        threads = []
         each_file do |path|
-          threads << Thread.new { stop_file(path) }
+          stop_file(path)
         end
-        ThreadsWait.all_waits(*threads)
       end
 
       def start_file(path)

--- a/spec/foreman_debian/initd/engine_spec.rb
+++ b/spec/foreman_debian/initd/engine_spec.rb
@@ -32,13 +32,15 @@ describe ForemanDebian::Initd::Engine, :fakefs do
 
   it 'starts script' do
     script_path = Pathname.new('/etc/init.d/foo')
-    engine.start_file(script_path)
-    expect(engine.commands_run).to be == ['/etc/init.d/foo start', 'update-rc.d foo defaults']
+    engine.stub(:get_files).and_return([script_path])
+    engine.start
+    expect(engine.commands_run).to include('/etc/init.d/foo start', 'update-rc.d foo defaults')
   end
 
   it 'stops script' do
     script_path = Pathname.new('/etc/init.d/foo')
-    engine.stop_file(script_path)
-    expect(engine.commands_run).to be == ['/etc/init.d/foo stop', 'update-rc.d -f foo remove']
+    engine.stub(:get_files).and_return([script_path])
+    engine.stop
+    expect(engine.commands_run).to include('/etc/init.d/foo stop', 'update-rc.d -f foo remove')
   end
 end


### PR DESCRIPTION
Incidents:

> *** [err :: www3.example.com (1.2.3.4)] /var/lib/gems/1.9.1/gems/foreman_debian-0.1.0/lib/foreman_debian/engine_helper.rb:51:in `block in exec_command': Command `update-rc.d -f sk-entertainment remove` failed: insserv: can not remove(../rc0.d/K02sk-maintenance_local): No such file or directory (RuntimeError)

> *** [err :: www3.example.com (1.2.3.4)] /var/lib/gems/1.9.1/gems/foreman_debian-0.1.0/lib/foreman_debian/engine_helper.rb:51:in `block in exec_command': Command `update-rc.d -f sk-jobs remove` failed: insserv: fopen(K02sk-maintenance_local): No such file or directory (RuntimeError)

@tomaszdurka any ideas? Are these links set correctly?