### PR TITLE
Installation is failing due to undefined method stop_file()

### DIFF
--- a/foreman_debian.gemspec
+++ b/foreman_debian.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'foreman_debian'
-s.version = '0.1.2B bu'
+  s.version = '0.1.2'
   s.summary = 'Foreman wrapper for debian'
   s.description = 'Wrapper around foreman and Procfile concept. It implements basic exporting, installing and uninstalling of initd scripts and monit configs for debian.'
   s.authors = %w(cargomedia tomaszdurka)

--- a/foreman_debian.gemspec
+++ b/foreman_debian.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'foreman_debian'
-  s.version = '0.1.1'
+s.version = '0.1.2B bu'
   s.summary = 'Foreman wrapper for debian'
   s.description = 'Wrapper around foreman and Procfile concept. It implements basic exporting, installing and uninstalling of initd scripts and monit configs for debian.'
   s.authors = %w(cargomedia tomaszdurka)

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -33,12 +33,20 @@ module ForemanDebian
         threads = []
         each_file do |path|
           threads << Thread.new do
-            exec_command("#{path.to_s} start")
+            start_process(path)
             @output.info "  start  #{path.to_s}"
           end
-          exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
+          start_run_on_boot(path)
         end
         ThreadsWait.all_waits(*threads)
+      end
+
+      def start_run_on_boot(path)
+        exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
+      end
+
+      def start_process(path)
+        exec_command("#{path.to_s} start")
       end
 
       def stop

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -46,15 +46,24 @@ module ForemanDebian
         each_file do |path|
           @output.info "   stop  #{path.to_s}"
           threads << Thread.new do
-            exec_command("#{path.to_s} stop")
+            stop_process(path)
           end
-          exec_command("update-rc.d -f #{path.basename} remove") if path.dirname.eql? @system_export_path
+          stop_run_on_boot(path)
         end
         ThreadsWait.all_waits(*threads)
       end
 
+      def stop_process(path)
+        exec_command("#{path.to_s} stop")
+      end
+
+      def stop_run_on_boot(path)
+        exec_command("update-rc.d -f #{path.basename} remove") if path.dirname.eql? @system_export_path
+      end
+
       def remove_file(path)
-        stop_file(path)
+        stop_process(path)
+        stop_run_on_boot(path)
         super(path)
       end
     end

--- a/lib/foreman_debian/initd/engine.rb
+++ b/lib/foreman_debian/initd/engine.rb
@@ -36,17 +36,9 @@ module ForemanDebian
             start_process(path)
             @output.info "  start  #{path.to_s}"
           end
-          start_run_on_boot(path)
+          enable_start_process_on_boot(path)
         end
         ThreadsWait.all_waits(*threads)
-      end
-
-      def start_run_on_boot(path)
-        exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
-      end
-
-      def start_process(path)
-        exec_command("#{path.to_s} start")
       end
 
       def stop
@@ -56,22 +48,30 @@ module ForemanDebian
           threads << Thread.new do
             stop_process(path)
           end
-          stop_run_on_boot(path)
+          disable_start_process_on_boot(path)
         end
         ThreadsWait.all_waits(*threads)
+      end
+
+      def start_process(path)
+        exec_command("#{path.to_s} start")
       end
 
       def stop_process(path)
         exec_command("#{path.to_s} stop")
       end
 
-      def stop_run_on_boot(path)
+      def enable_start_process_on_boot(path)
+        exec_command("update-rc.d #{path.basename} defaults") if path.dirname.eql? @system_export_path
+      end
+
+      def disable_start_process_on_boot(path)
         exec_command("update-rc.d -f #{path.basename} remove") if path.dirname.eql? @system_export_path
       end
 
       def remove_file(path)
         stop_process(path)
-        stop_run_on_boot(path)
+        disable_start_process_on_boot(path)
         super(path)
       end
     end


### PR DESCRIPTION
```
 ** [out :: server5.example.com (0.0.0.138)] I, [2015-09-21T13:53:14.973024 #11385]  INFO -- :  create  /etc/init.d/sk-jobs
 ** [out :: server5.example.com (0.0.0.138)] I, [2015-09-21T13:53:14.973657 #11385]  INFO -- :  create  /etc/monit/conf.d/sk-jobs
 ** [out :: server5.example.com (0.0.0.138)] I, [2015-09-21T13:53:14.974395 #11385]  INFO -- :  create  /etc/init.d/sk-maintenance_local
 ** [out :: server5.example.com (0.0.0.138)] I, [2015-09-21T13:53:14.974990 #11385]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance_local
 ** [out :: server4.example.com (0.0.0.160)] I, [2015-09-21T13:53:15.011468 #8065]  INFO -- :  create  /etc/init.d/sk-jobs
 ** [out :: server4.example.com (0.0.0.160)] I, [2015-09-21T13:53:15.012260 #8065]  INFO -- :  create  /etc/monit/conf.d/sk-jobs
 ** [out :: server4.example.com (0.0.0.160)] I, [2015-09-21T13:53:15.013347 #8065]  INFO -- :  create  /etc/init.d/sk-maintenance_local
 ** [out :: server4.example.com (0.0.0.160)] I, [2015-09-21T13:53:15.013955 #8065]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance_local
*** [err :: media2.example.com (0.0.0.154)] /var/lib/gems/1.9.1/gems/foreman_debian-0.1.1/lib/foreman_debian/initd/engine.rb:57:in `remove_file'
*** [err :: media2.example.com (0.0.0.154)] : undefined method `stop_file' for # (NoMethodError)
*** [err :: media2.example.com (0.0.0.154)] from /var/lib/gems/1.9.1/gems/foreman_debian-0.1.1/lib/foreman_debian/engine_helper.rb:18:in `block (2 levels) in cleanup'
 ** [out :: media2.example.com (0.0.0.154)] I, [2015-09-21T13:53:15.022790 #11156]  INFO -- :  create  /etc/init.d/sk-maintenance_local
 ** [out :: media2.example.com (0.0.0.154)] I, [2015-09-21T13:53:15.023824 #11156]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance_local
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.022265 #17972]  INFO -- :  create  /etc/init.d/sk-stream
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.022919 #17972]  INFO -- :  create  /etc/monit/conf.d/sk-stream
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.023848 #17972]  INFO -- :  create  /etc/init.d/sk-entertainment
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.024611 #17972]  INFO -- :  create  /etc/monit/conf.d/sk-entertainment
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.025389 #17972]  INFO -- :  create  /etc/init.d/sk-jobs
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.026667 #17972]  INFO -- :  create  /etc/init.d/sk-maintenance
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.027309 #17972]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.027700 #17972]  INFO -- :  create  /etc/monit/conf.d/sk-jobs
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.028383 #17972]  INFO -- :  create  /etc/init.d/sk-maintenance_local
 ** [out :: server3.example.com (0.0.0.166)] I, [2015-09-21T13:53:15.029031 #17972]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance_local
*** [err :: searchserver2.example.com (0.0.0.156)] /var/lib/gems/1.9.1/gems/foreman_debian-0.1.1/lib/foreman_debian/initd/engine.rb:57:in `remove_file'
*** [err :: searchserver2.example.com (0.0.0.156)] : undefined method `stop_file' for # (NoMethodError)
*** [err :: searchserver2.example.com (0.0.0.156)] from /var/lib/gems/1.9.1/gems/foreman_debian-0.1.1/lib/foreman_debian/engine_helper.rb:18:in `block (2 levels) in cleanup'
 ** [out :: searchserver2.example.com (0.0.0.156)] I, [2015-09-21T13:53:15.050336 #16385]  INFO -- :  create  /etc/init.d/sk-maintenance_local
 ** [out :: searchserver2.example.com (0.0.0.156)] I, [2015-09-21T13:53:15.051408 #16385]  INFO -- :  create  /etc/monit/conf.d/sk-maintenance_local
 ** [out :: searchserver2.example.com (0.0.0.156)] I, [2015-09-21T13:53:15.053120 #16385]  INFO -- :  create  /etc/init.d/sk-searchserver
 ** [out :: searchserver2.example.com (0.0.0.156)] I, [2015-09-21T13:53:15.054201 #16385]  INFO -- :  create  /etc/monit/conf.d/sk-searchserver
    command finished in 243ms
failed: "sh -c 'sudo -p '\\''sudo password: '\\'' foreman-debian install -d $(readlink /home/example/serve) --app sk --user example --concurrency maintenance_local=1,searchserver=1'" on searchserver2.example.com (0.0.0.156); "sh -c 'sudo -p '\\''sudo password: '\\'' foreman-debian install -d $(readlink /home/example/serve) --app sk --user example --concurrency maintenance_local=1'" on media2.example.com (0.0.0.154)
/var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/shell.rb:22:in `run_cmd': Command bundle exec cap CONFIG_PATH=/home/pulsar-rest-api/.pulsar/tmp/conf-repo-2015-09-21-134728-s4595 --file /home/pulsar-rest-api/.pulsar/tmp/capfile-2015-09-21-134730-s6109 deploy -s revision\=d18ec556306ce535c8ec4b8cef45db1d91e0edce Failed (RuntimeError)
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/clamp.rb:176:in `block in run_capistrano'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/shell.rb:10:in `block in cd'
	from /usr/lib/ruby/1.9.1/fileutils.rb:125:in `chdir'
	from /usr/lib/ruby/1.9.1/fileutils.rb:125:in `cd'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/shell.rb:10:in `cd'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/clamp.rb:175:in `run_capistrano'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/commands/main.rb:58:in `validate_and_run_capistrano'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/commands/main.rb:30:in `block (2 levels) in execute'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/commands/main.rb:30:in `each'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/commands/main.rb:30:in `block in execute'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/clamp.rb:217:in `block in with_clean_env_and_supported_vars'
	from /var/lib/gems/1.9.1/gems/bundler-1.7.12/lib/bundler.rb:236:in `block in with_clean_env'
	from /var/lib/gems/1.9.1/gems/bundler-1.7.12/lib/bundler.rb:223:in `with_original_env'
	from /var/lib/gems/1.9.1/gems/bundler-1.7.12/lib/bundler.rb:229:in `with_clean_env'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/helpers/clamp.rb:215:in `with_clean_env_and_supported_vars'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/lib/pulsar/commands/main.rb:27:in `execute'
	from /var/lib/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
	from /var/lib/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:125:in `run'
	from /var/lib/gems/1.9.1/gems/pulsar-0.3.5/bin/pulsar:5:in `'
	from /usr/local/bin/pulsar:23:in `load'
	from /usr/local/bin/pulsar:23:in `
```

@tomaszdurka any ideas?